### PR TITLE
Unsuccesful login message

### DIFF
--- a/app/src/authentication/authentication.component.js
+++ b/app/src/authentication/authentication.component.js
@@ -5,7 +5,6 @@
 			.controller('LoginCtrl', ['$scope', '$rootScope', '$state','$mdToast', 'AUTH_EVENTS', 'AuthService', LoginCtrl]);
 
 		function LoginCtrl($scope, $rootScope, $state,$mdToast, AUTH_EVENTS, AuthService) {
-
 			$scope.doLogin = function() {
 		        AuthService.doLogin($scope.loginData).save().$promise.then(function(result) {
 		        	AuthService.setUser(result);
@@ -16,6 +15,9 @@
 				          .position('top right')
 				    );
 	                $state.go("app.clients");
+				}, function(result){
+					$scope.err = result.data.defaultUserMessage;
+					console.log(result.data.developerMessage);
 				});
 			}
 			

--- a/app/src/authentication/authentication.html
+++ b/app/src/authentication/authentication.html
@@ -18,7 +18,7 @@
         <md-icon md-svg-src="assets/images/ic_remove_red_eye_black_24px.svg" class="password"></md-icon>
         <input type="password" ng-model="loginData.password">
       </md-input-container>
-
+      <section layout="column" align="center" style="color:red;font-size:15px">{{err}}</section>
       <section layout="column" layout-align="start">
         <md-button class="md-primary md-raised" ng-click="doLogin()">Login</md-button>
       </section>


### PR DESCRIPTION
Whenever login is unsuccessful due to any reason, a corresponding message is shown in red text.
For eg: If the server takes too long to respond (timeout), a message with corresponding code and text will appear above the login button.

![screenshot 88](https://cloud.githubusercontent.com/assets/20579129/23806213/ccc454c2-05e6-11e7-9e28-9748c3ec4e27.png)

Affected urls:
/login