### PR TITLE
#38 Maps fallback locale to ensure label text loading

### DIFF
--- a/app/app.config.js
+++ b/app/app.config.js
@@ -57,11 +57,15 @@
           // Mifos set Tenant
           $httpProvider.defaults.headers.common['Fineract-Platform-TenantId'] = 'default';
 
-          $translateProvider.useStaticFilesLoader({
+          const defaultLocale = 'en';
+          $translateProvider
+            .useStaticFilesLoader({
               prefix: 'global-translations/locale-',
               suffix: '.json'
-          });
-          $translateProvider.preferredLanguage('en');
+            })
+            .useSanitizeValueStrategy('escape')
+            .preferredLanguage(defaultLocale)
+            .fallbackLanguage(defaultLocale);
 
         }
       )


### PR DESCRIPTION
- Adds `en` as a fallback language that will inject the English translation for labels that don't exist in other language files.
- Adds a sanitization strategy for security. Hindi, unfortunately, is garbled by the `sanitize` strategy recommended by the [`angular-translate` documentation](https://angular-translate.github.io/docs/#/guide/10_storages)

Authentication on a local development environment was not clear, so I did a sanity check by removing the login button label in the Hindi locale file and validating that the fallback appeared.

## Without Fallback

<img width="433" alt="screen shot 2017-10-18 at 8 57 09 pm" src="https://user-images.githubusercontent.com/784889/31753949-15a290da-b449-11e7-8c71-5a3605eea8bd.png">

## With Fallback

<img width="437" alt="screen shot 2017-10-18 at 9 03 02 pm" src="https://user-images.githubusercontent.com/784889/31753950-15b9474e-b449-11e7-8935-8032798e74d0.png">
