### PR TITLE
Fix #65 Prevent access to login page if user already logged in

### DIFF
--- a/app/app.config.js
+++ b/app/app.config.js
@@ -69,12 +69,18 @@
       )
 
       .run(['$rootScope', '$location', 'AuthService', function($rootScope, $location, AuthService) {
-            $rootScope.$on('$locationChangeStart', function () {
+            $rootScope.$on('$locationChangeStart', function (event, next, current) {
                 // redirect to login page if not logged in and trying to access a restricted page
+                // prevent access to login page when user already logged in and authenticated
                 var restrictedPage = $.inArray($location.path(), ['/login']) === -1;
                 var loggedIn = AuthService.isAuthenticated();
-                if (restrictedPage && !loggedIn) {
-                      $location.path('/login');
+                if (restrictedPage) {
+                    if(!loggedIn) {
+                        $location.path('/login');
+                    }
+                }
+                else if(loggedIn) {
+                    event.preventDefault();
                 }
             });
       }])


### PR DESCRIPTION
The user cannot access the login page now if he is already authenticated and logged in.
 ( issue #65 )