### PR TITLE
Fix #68 Clear textfields on pressing Cancel

### DIFF
--- a/app/src/loan-application/loan-application.component.js
+++ b/app/src/loan-application/loan-application.component.js
@@ -2,14 +2,14 @@
     'use strict';
 
     angular.module('selfService')
-        .controller('LoanApplicationCtrl', ['$filter', '$mdToast', 'AccountService', 'LoanApplicationService', LoanApplicationCtrl]);
+        .controller('LoanApplicationCtrl', ['$scope', '$filter', '$mdToast', 'AccountService', 'LoanApplicationService', LoanApplicationCtrl]);
 
     /**
      * @module LoanApplicationCtrl
      * @description
      * Controls Application for Loan
      */
-    function LoanApplicationCtrl($filter, $mdToast, AccountService, LoanApplicationService) {
+    function LoanApplicationCtrl($scope, $filter, $mdToast, AccountService, LoanApplicationService) {
         var vm = this;
 
         vm.form = {
@@ -22,6 +22,7 @@
 
         vm.init = init;
         vm.getLoanTemplate = getLoanTemplate;
+        vm.clearForm = clearForm;
         vm.submit = submit;
 
         init();
@@ -46,6 +47,18 @@
             });
         }
 
+        function clearForm() {
+            $scope.loanApplicationForm.$setPristine();
+            $scope.loanApplicationForm.$setUntouched();
+            vm.template = {};
+            vm.form = {
+                locale: 'en_GB',
+                dateFormat: 'dd MMMM yyyy',
+                loanType: 'individual'
+            };
+            init();
+        }
+
         function submit() {
             var loanTemp = {
                 clientId: vm.clientId,
@@ -62,6 +75,7 @@
             };
             var data = Object.assign({}, loanTemp, vm.form);
             LoanApplicationService.loan().save(data).$promise.then(function(resp) {
+                clearForm();
                 $mdToast.show(
                     $mdToast.simple()
                         .content("Loan Application Submitted Successfully")

--- a/app/src/loan-application/loan-application.html
+++ b/app/src/loan-application/loan-application.html
@@ -43,7 +43,7 @@
                 </md-input-container>
                 <br />
                 <div layout="row" flex>
-                    <md-button flex class="md-danger">{{ 'label.btn.cancel' | translate }}</md-button>
+                    <md-button flex class="md-danger" ng-click="vm.clearForm()">{{ 'label.btn.cancel' | translate }}</md-button>
                     <md-button type="submit" flex class="md-raised md-primary" ng-disabled="transferForm.$invalid">{{ 'label.btn.apply' | translate }}</md-button>
                 </div>
 

--- a/app/src/tpt/tpt.component.js
+++ b/app/src/tpt/tpt.component.js
@@ -12,6 +12,7 @@
         vm.transferFormData = getTransferFormDataObj()
 
         vm.getTransferTemplate = getTransferTemplate();
+        vm.clearForm = clearForm;
         vm.submit = submit;
 
         // FORMAT THE DATE FOR THE DATEPICKER

--- a/app/src/tpt/tpt.html
+++ b/app/src/tpt/tpt.html
@@ -34,7 +34,7 @@
                     <input name="remark" ng-model="vm.transferFormData.remark" required>
                 </md-input-container>
                 <div layout="row" flex>
-                    <md-button flex class="md-danger">{{ 'label.btn.cancel' | translate }}</md-button>
+                    <md-button flex class="md-danger" ng-click="vm.clearForm()">{{ 'label.btn.cancel' | translate }}</md-button>
                     <md-button type="submit" flex class="md-raised md-primary" ng-disabled="transferForm.$invalid">{{ 'label.btn.reviewTransfer' | translate }}</md-button>
                 </div>
 

--- a/app/src/transfers/transfers.component.js
+++ b/app/src/transfers/transfers.component.js
@@ -21,6 +21,7 @@
 
         vm.transferFormData = getTransferFormDataObj();
         vm.getTransferTemplate = getTransferTemplate();
+        vm.clearForm = clearForm;
         vm.submit = submit;
 
         // FORMAT THE DATE FOR THE DATEPICKER

--- a/app/src/transfers/transfers.html
+++ b/app/src/transfers/transfers.html
@@ -34,7 +34,7 @@
                     <input name="remark" ng-model="vm.transferFormData.remark" required>
                 </md-input-container>
                 <div layout="row" flex>
-                    <md-button flex class="md-danger">{{ 'label.btn.cancel' | translate }}</md-button>
+                    <md-button flex class="md-danger" ng-click="vm.clearForm()">{{ 'label.btn.cancel' | translate }}</md-button>
                     <md-button type="submit" flex class="md-raised md-primary" ng-disabled="transferForm.$invalid">{{ 'label.btn.reviewTransfer' | translate }}</md-button>
                 </div>
 


### PR DESCRIPTION
On pressing cancel in transfers, third-party transfers and apply for loan section the text fields are now cleared.

Fixes #68 

Demonstration:
![issue_68 wssa](https://user-images.githubusercontent.com/16948598/36356817-7edf655c-151d-11e8-8571-e52270e697fa.gif)
![issue_68 wssa 1](https://user-images.githubusercontent.com/16948598/36356827-b3b9d92e-151d-11e8-94a6-06bf6092de2c.gif)
![issue_68 wssa 2](https://user-images.githubusercontent.com/16948598/36356832-cfd9cd76-151d-11e8-879f-240b2052a339.gif)