### PR TITLE
Fixed #78: Hamburger is now on the left

### DIFF
--- a/app/src/common/main.html
+++ b/app/src/common/main.html
@@ -86,7 +86,7 @@
 
 <div layout="column" flex>
     <md-toolbar md-theme="default" layout="row" layout-align="end center">
-        <md-button hide-gt-sm ng-click="vm.toggleItemsList()" aria-label="Menu">
+        <md-button hide-gt-sm ng-click="vm.toggleItemsList()" style="margin-right: auto" aria-label="Menu">
             <i class="material-icons">menu</i>
         </md-button>
         <md-menu md-position-mode="target-right target">


### PR DESCRIPTION
The hamburger (in the responsive view) is now on the left side (as per common UX practices).

![self service 78 fix](https://user-images.githubusercontent.com/29003134/36380157-4bc4b89a-15a7-11e8-9b1f-ec2bc5b7b7b3.png)
