### PR TITLE
Made side nav icons visible in tablet view

### DIFF
--- a/app/src/common/main.html
+++ b/app/src/common/main.html
@@ -16,63 +16,63 @@
         <md-button ng-click="vm.selectItem('Dashboard')" ui-sref-active="md-warn"
                    ui-sref=".dashboard">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">home</i> {{ 'nav.label.dashboard' | translate}}
+                <i class="material-icons md-18">home</i> {{ 'nav.label.dashboard' | translate}}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('Accounts')" ui-sref-active="md-warn" ui-sref=".accounts"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">account_balance_wallet</i> {{ 'nav.label.accounts' | translate}}
+                <i class="material-icons md-18">account_balance_wallet</i> {{ 'nav.label.accounts' | translate}}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('Recent Transactions')" ui-sref-active="md-warn"
                    ui-sref=".recenttransactions" class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">trending_up</i> {{ 'nav.label.recenttransactions' | translate}}
+                <i class="material-icons md-18">trending_up</i> {{ 'nav.label.recenttransactions' | translate}}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('Charges')" ui-sref-active="md-warn" ui-sref=".charges"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">attach_money</i> {{ 'nav.label.charges' | translate }}
+                <i class="material-icons md-18">attach_money</i> {{ 'nav.label.charges' | translate }}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('Transfers')" ui-sref-active="md-warn" ui-sref=".transfers"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">attach_money</i> {{ 'nav.label.transfers' | translate }}
+                <i class="material-icons md-18">attach_money</i> {{ 'nav.label.transfers' | translate }}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('TPT Transfers')" ui-sref-active="md-warn" ui-sref=".tpt"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">attach_money</i> {{ 'nav.label.tpttransfers' | translate }}
+                <i class="material-icons md-18">attach_money</i> {{ 'nav.label.tpttransfers' | translate }}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('Beneficiaries')" ui-sref-active="md-warn" ui-sref=".beneficiarieslist"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">group</i> {{ 'nav.label.beneficiaries' | translate }}
+                <i class="material-icons md-18">group</i> {{ 'nav.label.beneficiaries' | translate }}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('Reports')" ui-sref-active="md-warn" ui-sref=".reports"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">ballot</i> {{ 'nav.label.reports' | translate }}
+                <i class="material-icons md-18">ballot</i> {{ 'nav.label.reports' | translate }}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('Apply Loan')" ui-sref-active="md-warn" ui-sref=".applyloan"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">assignment</i> {{ 'nav.label.applyloan' | translate }}
+                <i class="material-icons md-18">assignment</i> {{ 'nav.label.applyloan' | translate }}
             </div>
         </md-button>
         <md-divider></md-divider>
@@ -93,14 +93,14 @@
         <md-button ng-click="vm.selectItem('About Us')" ui-sref-active="md-warn" ui-sref=".aboutus"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">info</i> {{ 'nav.label.aboutus' | translate }}
+                <i class="material-icons md-18">info</i> {{ 'nav.label.aboutus' | translate }}
             </div>
         </md-button>
         <md-divider></md-divider>
         <md-button ng-click="vm.selectItem('Help')" ui-sref-active="md-warn" ui-sref=".help"
                    class="sidenav-icon">
             <div class="md-tile-content">
-                <i hide-sm hide-md class="material-icons md-18">help</i> {{ 'nav.label.help' | translate }}
+                <i class="material-icons md-18">help</i> {{ 'nav.label.help' | translate }}
             </div>
         </md-button>
     </md-content>


### PR DESCRIPTION
Fixed #117 
Made side nav icons visible in tablet view. Earlier they were not visible in tablet view although they were visible in desktop and mobile view.
![screenshot from 2018-07-12 22-11-15](https://user-images.githubusercontent.com/21126132/42647088-88807776-8620-11e8-8c7e-a83adb8c122b.png)