### PR TITLE
Fix #140: Dashboard Button Click Area Fixed

### DIFF
--- a/app/src/common/main.html
+++ b/app/src/common/main.html
@@ -13,8 +13,8 @@
           Close
         </md-button> -->
         <md-divider></md-divider>
-        <md-button ng-click="vm.selectItem('Dashboard')" ui-sref-active="md-warn"
-                   ui-sref=".dashboard">
+        <md-button ng-click="vm.selectItem('Dashboard')" ui-sref-active="md-warn" ui-sref=".dashboard"
+                   class="sidenav-icon">
             <div class="md-tile-content">
                 <i hide-sm hide-md class="material-icons md-18">home</i> {{ 'nav.label.dashboard' | translate}}
             </div>


### PR DESCRIPTION
Fixes Issue #140.

## Description:
Added class to dashboard item on side nav bar so that you can click the whole tab. Made style of code consistent with rest of tabs.

## GIF:
![dashboard](https://user-images.githubusercontent.com/41968151/48793464-a4f00400-ecbc-11e8-98e0-9ab58af5378d.gif)