### PR TITLE
Fix #142: 'Apply' Button for Loans Now Grayed Out When Fields Are Empty

### DIFF
--- a/app/src/loan-application/loan-application.html
+++ b/app/src/loan-application/loan-application.html
@@ -45,7 +45,7 @@
                 <br />
                 <div layout="row" flex>
                     <md-button flex class="md-danger" ng-click="vm.clearForm()">{{ 'label.btn.cancel' | translate }}</md-button>
-                    <md-button type="submit" flex class="md-raised md-primary" ng-disabled="transferForm.$invalid">{{ 'label.btn.apply' | translate }}</md-button>
+                    <md-button type="submit" flex class="md-raised md-primary" ng-disabled="loanApplicationForm.$invalid">{{ 'label.btn.apply' | translate }}</md-button>
                 </div>
 
             </form>


### PR DESCRIPTION
Fixes #142 

## Description:
Changed `transferForm` to `loanApplication`, which was probably an accidental mistake. Now the button is grayed out like the issue describes.

## GIF:
![loanbuttonfix](https://user-images.githubusercontent.com/41968151/48800146-914d9900-ecce-11e8-8726-3f48124e2d73.gif)