### PR TITLE
Fixes #144: Generate Graph Inputs Not Full Size

### DIFF
--- a/app/src/dashboard/dashboard.html
+++ b/app/src/dashboard/dashboard.html
@@ -95,13 +95,13 @@
                 <form name="transactionGraphForm" ng-submit="transactionGraphForm.$valid && vm.submit()">
                     <div layout="row">
                         <div flex-gt-md="40">
-                            <md-input-container class="md-block" flex="33">
+                            <md-input-container class="md-block" flex="100">
                                 <label>{{'label.input.accountno' | translate}}</label>
                                 <input name="account_no" ng-model="vm.accountno" required>
                             </md-input-container>
                         </div>
                         <div flex-gt-md="40">
-                            <md-input-container class="md-block" flex="33">
+                            <md-input-container class="md-block" flex="100">
                                 <label>{{'label.input.accountType' | translate}}</label>
                                 <md-select ng-model="vm.accountType" ng-change="vm.accountType" required>
                                     <md-option ng-repeat="accountType in vm.accountTypeOptions" ng-value="accountType">{{ accountType }}</md-option>
@@ -109,7 +109,7 @@
                             </md-input-container>
                         </div>
                         <div flex-gt-md="40" ng-if="vm.accountno && vm.accountType">
-                            <md-input-container class="md-block" flex="33">
+                            <md-input-container class="md-block" flex="100">
                                 <label>{{'label.input.transactionType' | translate}}</label>
                                 <md-select ng-model="vm.paymentType" ng-click="vm.selectPayment(vm.paymentType)" ng-change="vm.selectPayment(vm.paymentType)" required>
                                     <md-option ng-repeat="paymentType in vm.paymentTypes" ng-value="paymentType">{{ paymentType }}</md-option>


### PR DESCRIPTION
## Description
The inputs for generating a graph on the dashboard screen were not going to full size even with available space as shown in #144. By making flex 100%, the input fields will take up the whole row and are still responsive.

## Screenshots/GIFs, if any:
![flex](https://user-images.githubusercontent.com/41968151/49352554-11381380-f67e-11e8-8fc4-5712bf63ec89.gif)