### PR TITLE
Fix #158: Change mobile input type from 'phone' to 'number'

### DIFF
--- a/app/src/authentication/register/register.html
+++ b/app/src/authentication/register/register.html
@@ -62,7 +62,7 @@
                 </md-input-container>
 
                 <md-input-container class="md-block" md-no-float>
-                    <input type="phone" name="mobile" ng-model="vm.form.mobileNumber" placeholder="Mobile">
+                    <input type="number" name="mobile" ng-model="vm.form.mobileNumber" placeholder="Mobile">
                 </md-input-container>
 
                 <md-input-container class="md-block" md-no-float>


### PR DESCRIPTION
Thank you for contributing to Mifos web self-service.

## Description
Changed the input type of the mobile number field from 'phone' to 'number' in the registration form to restrict user input to numbers only.

## Related issues and discussion
Fixes #158

## Screenshots/GIFs, if any:
N/A